### PR TITLE
modified Berksfile to use https instead of ssh

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,4 +2,6 @@ source "https://supermarket.chef.io"
 
 metadata
 
-cookbook 'delivery-sugar', github: 'chef-cookbooks/delivery-sugar'
+cookbook 'delivery-sugar',
+  git: 'https://github.com/chef-cookbooks/delivery-sugar.git',
+  branch: 'master'


### PR DESCRIPTION
#9 proposed fix to switch to https over git

makes places that block ssh outside of their intranet very happy :-)