### PR TITLE
Adding general Git Server support

### DIFF
--- a/libraries/helpers_publish.rb
+++ b/libraries/helpers_publish.rb
@@ -43,6 +43,17 @@ module DeliveryTruck
         false
       end
 
+      # Read the Delivery Config to see if the user has indicated a Git Server
+      # repo they would like to push to.
+      #
+      # @param [Chef::Node] Chef Node object
+      # @return [TrueClass, FalseClass]
+      def push_repo_to_git?(node)
+        !!node['delivery']['config']['delivery-truck']['publish']['git']
+      rescue
+        false
+      end
+
       # Read the Delivery Config to see if the user has indicated a Supermarket
       # Server they would like to share to.
       #
@@ -65,6 +76,11 @@ module DeliveryTruck
     # Check config.json for whether user wants to push to Github
     def push_repo_to_github?
       DeliveryTruck::Helpers::Publish.push_repo_to_github?(node)
+    end
+
+    # Check config.json for whether user wants to push to a Git Server
+     def push_repo_to_git?
+      DeliveryTruck::Helpers::Publish.push_repo_to_git?(node)
     end
 
     # Check config.json for whether user wants to share to Supermarket

--- a/recipes/publish.rb
+++ b/recipes/publish.rb
@@ -103,3 +103,18 @@ if push_repo_to_github?
     action :push
   end
 end
+
+# If the user specified a general git repo to push to, push to that repo
+if push_repo_to_git?
+  secrets = get_project_secrets
+  git_repo = node['delivery']['config']['delivery-truck']['publish']['git']
+  
+  delivery_github git_repo do
+    deploy_key secrets['git_key']
+    branch node['delivery']['change']['pipeline']
+    remote_url "#{git_repo}"
+    repo_path node['delivery']['workspace']['repo']
+    cache_path node['delivery']['workspace']['cache']
+    action :push
+  end
+end


### PR DESCRIPTION
Added support for a generic "git" tag to be added to the .delivery/config.json file. The blob looks like this:

```json
"delivery-truck": {
  "publish": {
  "chef_server": true,
  "git": "ssh://git@stash:2222/<project-name>/<repo-name>.git"
}
```

Only supports SSH.